### PR TITLE
Feature: add a way to set Cloudflare AI Gateway options

### DIFF
--- a/packages/ai-provider/src/workersai-chat-language-model.ts
+++ b/packages/ai-provider/src/workersai-chat-language-model.ts
@@ -143,6 +143,9 @@ export class WorkersAIChatLanguageModel implements LanguageModelV1 {
 
     const response = await this.config.binding.run(args.model, {
       messages: args.messages,
+    }, 
+    {
+      gateway: this.settings.gateway
     });
 
     if (response instanceof ReadableStream) {

--- a/packages/ai-provider/src/workersai-chat-settings.ts
+++ b/packages/ai-provider/src/workersai-chat-settings.ts
@@ -5,4 +5,5 @@ export interface WorkersAIChatSettings {
   Defaults to `false`.
      */
   safePrompt?: boolean;
+  gateway?: GatewayOptions
 }

--- a/packages/ai-provider/src/workersai-chat-settings.ts
+++ b/packages/ai-provider/src/workersai-chat-settings.ts
@@ -5,5 +5,8 @@ export interface WorkersAIChatSettings {
   Defaults to `false`.
      */
   safePrompt?: boolean;
+  /**
+   * Optionally set Cloudflare AI Gateway options.
+   */
   gateway?: GatewayOptions
 }


### PR DESCRIPTION
Using the SDK provider I noticed there wasn't a way to pass through the options for AI Gateway setup. This is a small tweak to enable that.