### PR TITLE
Add support for promptTokens and completionsTokens

### DIFF
--- a/packages/ai-provider/src/workersai-chat-language-model.ts
+++ b/packages/ai-provider/src/workersai-chat-language-model.ts
@@ -198,7 +198,7 @@ export class WorkersAIChatLanguageModel implements LanguageModelV1 {
             const chunkToText = decoder.decode(chunk as unknown as Uint8Array);
             const chunks = events(new Response(chunkToText));
             let promptTokens = 0;
-            let completionTokens = 0;            
+            let completionTokens = 0;
             for await (const singleChunk of chunks) {
               if (!singleChunk.data) {
                 continue;
@@ -218,8 +218,8 @@ export class WorkersAIChatLanguageModel implements LanguageModelV1 {
 
               // Usage stats are reported in a final data message (with data.response set to ""), before "[DONE]".
               if(data.usage) {
-                promptTokens = data.usage.prompt_tokens;
-                completionTokens = data.usage.completion_tokens;
+                promptTokens = data.usage.prompt_tokens ?? 0;
+                completionTokens = data.usage.completion_tokens ?? 0;
               }
               
               controller.enqueue({

--- a/packages/ai-provider/src/workersai-chat-language-model.ts
+++ b/packages/ai-provider/src/workersai-chat-language-model.ts
@@ -188,6 +188,9 @@ export class WorkersAIChatLanguageModel implements LanguageModelV1 {
       throw new Error("This shouldn't happen");
     }
 
+    let promptTokens = 0;
+    let completionTokens = 0;
+
     return {
       stream: response.pipeThrough(
         new TransformStream<
@@ -197,8 +200,6 @@ export class WorkersAIChatLanguageModel implements LanguageModelV1 {
           async transform(chunk, controller) {
             const chunkToText = decoder.decode(chunk as unknown as Uint8Array);
             const chunks = events(new Response(chunkToText));
-            let promptTokens = 0;
-            let completionTokens = 0;
             for await (const singleChunk of chunks) {
               if (!singleChunk.data) {
                 continue;

--- a/packages/ai-provider/src/workersai-chat-language-model.ts
+++ b/packages/ai-provider/src/workersai-chat-language-model.ts
@@ -164,9 +164,9 @@ export class WorkersAIChatLanguageModel implements LanguageModelV1 {
       finishReason: "stop", // TODO: mapWorkersAIFinishReason(response.finish_reason),
       rawCall: { rawPrompt: args.messages, rawSettings: args },
       usage: {
-        // TODO: mapWorkersAIUsage(response.usage),
-        promptTokens: 0,
-        completionTokens: 0,
+        // TODO: create mapWorkersAIUsage(response.usage) and do mapping there instead,
+        promptTokens: response.usage?.prompt_tokens ?? 0,
+        completionTokens: response.usage?.completion_tokens ?? 0,
       },
       warnings,
     };

--- a/packages/ai-provider/src/workersai-chat-language-model.ts
+++ b/packages/ai-provider/src/workersai-chat-language-model.ts
@@ -197,8 +197,8 @@ export class WorkersAIChatLanguageModel implements LanguageModelV1 {
           async transform(chunk, controller) {
             const chunkToText = decoder.decode(chunk as unknown as Uint8Array);
             const chunks = events(new Response(chunkToText));
-            const promptTokens = 0;
-            const completionTokens = 0;            
+            let promptTokens = 0;
+            let completionTokens = 0;            
             for await (const singleChunk of chunks) {
               if (!singleChunk.data) {
                 continue;
@@ -231,8 +231,8 @@ export class WorkersAIChatLanguageModel implements LanguageModelV1 {
               type: "finish",
               finishReason: "stop",
               usage: {
-                promptTokens: 0,
-                completionTokens: 0,
+                promptTokens: promptTokens,
+                completionTokens: completionTokens,
               },
             });
           },


### PR DESCRIPTION
The motivation behind this pull request is a question on the Developer Discord regarding why `promptTokens`  and `completionTokens` always contain 0 instead of the actual number of tokens. 

Quick/initial implementation, i.e. not placed in separate method as suggested by the original TODO. Tested in local dev (`npx wrangler dev --remote`).

Note that the possibility to get usage statistics from streaming responses is currently not documented in the Workers AI API. The implementation is based on observed behavior.