### PR TITLE
Fix: Cloudflare AI Gateway options does not work with doStream

### DIFF
--- a/packages/ai-provider/src/index.ts
+++ b/packages/ai-provider/src/index.ts
@@ -29,6 +29,10 @@ binding = "AI"
   ```
    **/
   binding: Ai;
+  /**
+   * Optionally set Cloudflare AI Gateway options.
+   */
+  gateway?: GatewayOptions;
 }
 
 /**

--- a/packages/ai-provider/src/index.ts
+++ b/packages/ai-provider/src/index.ts
@@ -46,6 +46,7 @@ export function createWorkersAI(options: WorkersAISettings): WorkersAI {
     new WorkersAIChatLanguageModel(modelId, settings, {
       provider: "workersai.chat",
       binding: options.binding,
+      gateway: options.gateway,
     });
 
   const provider = function (

--- a/packages/ai-provider/src/workersai-chat-language-model.ts
+++ b/packages/ai-provider/src/workersai-chat-language-model.ts
@@ -14,6 +14,7 @@ import { events } from "fetch-event-stream";
 type WorkersAIChatConfig = {
   provider: string;
   binding: Ai;
+  gateway?: GatewayOptions;
 };
 
 export class WorkersAIChatLanguageModel implements LanguageModelV1 {
@@ -136,13 +137,8 @@ export class WorkersAIChatLanguageModel implements LanguageModelV1 {
 
     const output = await this.config.binding.run(
       args.model,
-      {
-        messages: args.messages,
-        tools: args.tools,
-      },
-      {
-        gateway: this.settings.gateway,
-      }
+      { messages: args.messages, tools: args.tools },
+      { gateway: this.config.gateway ?? this.settings.gateway }
     );
 
     if (output instanceof ReadableStream) {
@@ -173,11 +169,11 @@ export class WorkersAIChatLanguageModel implements LanguageModelV1 {
   ): Promise<Awaited<ReturnType<LanguageModelV1["doStream"]>>> {
     const { args, warnings } = this.getArgs(options);
 
-    const response = await this.config.binding.run(args.model, {
-      messages: args.messages,
-      stream: true,
-      tools: args.tools,
-    });
+    const response = await this.config.binding.run(
+      args.model,
+      { messages: args.messages, stream: true, tools: args.tools },
+      { gateway: this.config.gateway ?? this.settings.gateway }
+    );
 
     if (!(response instanceof ReadableStream)) {
       throw new Error("This shouldn't happen");

--- a/packages/ai-provider/src/workersai-chat-language-model.ts
+++ b/packages/ai-provider/src/workersai-chat-language-model.ts
@@ -137,7 +137,13 @@ export class WorkersAIChatLanguageModel implements LanguageModelV1 {
 
     const output = await this.config.binding.run(
       args.model,
-      { messages: args.messages, tools: args.tools },
+      {
+        messages: args.messages,
+        max_tokens: args.max_tokens,
+        temperature: args.temperature,
+        top_p: args.top_p,
+        tools: args.tools,
+      },
       { gateway: this.config.gateway ?? this.settings.gateway }
     );
 
@@ -171,7 +177,14 @@ export class WorkersAIChatLanguageModel implements LanguageModelV1 {
 
     const response = await this.config.binding.run(
       args.model,
-      { messages: args.messages, stream: true, tools: args.tools },
+      {
+        messages: args.messages,
+        max_tokens: args.max_tokens,
+        temperature: args.temperature,
+        top_p: args.top_p,
+        stream: true,
+        tools: args.tools,
+      },
       { gateway: this.config.gateway ?? this.settings.gateway }
     );
 

--- a/packages/ai-provider/src/workersai-chat-settings.ts
+++ b/packages/ai-provider/src/workersai-chat-settings.ts
@@ -7,6 +7,7 @@ export interface WorkersAIChatSettings {
   safePrompt?: boolean;
   /**
    * Optionally set Cloudflare AI Gateway options.
+   * @deprecated
    */
-  gateway?: GatewayOptions
+  gateway?: GatewayOptions;
 }


### PR DESCRIPTION
This pull request fixes #14 where gateway option was not enabled for `doStream`.

I think the gateway option should be configured with `createWorkersAI` so move this option to `WorkersAISettings`.