### PR TITLE
Add tool calling to generateText

### DIFF
--- a/.changeset/tough-wasps-peel.md
+++ b/.changeset/tough-wasps-peel.md
@@ -1,0 +1,5 @@
+---
+"workers-ai-provider": patch
+---
+
+Fixes tool calling for generateText

--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,6 @@ lerna-debug.log*
 
 # misc
 .DS_Store
+.idea
 
 /random

--- a/examples/ai-chat/src/server/index.ts
+++ b/examples/ai-chat/src/server/index.ts
@@ -18,7 +18,6 @@ export default {
         messages: Parameters<typeof convertToCoreMessages>[0];
       }>();
       const result = streamText({
-        // @ts-expect-error
         model: workersai("@cf/meta/llama-3.3-70b-instruct-fp8-fast"),
         messages: convertToCoreMessages(messages),
       });

--- a/examples/tool-calling/package.json
+++ b/examples/tool-calling/package.json
@@ -1,11 +1,12 @@
 {
-  "name": "@cloudflare/example-ai-chat",
+  "name": "@cloudflare/example-tool-calling",
   "private": true,
   "scripts": {
     "start": "wrangler dev",
     "deploy": "wrangler deploy"
   },
   "dependencies": {
+    "@ai-sdk/openai": "^1.1.9",
     "ai": "^4.0.14",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/examples/tool-calling/public/index.html
+++ b/examples/tool-calling/public/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Vercel AI ⤫ Workers AI" />
+    <title>Workers AI Tool Calling</title>
+
+    <link
+      rel="icon"
+      href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🙂‍↔️</text></svg>"
+    />
+
+    <!-- Link to Google Fonts -->
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap"
+    />
+
+    <!-- Favicon -->
+    <link rel="icon" href="favicon.ico" type="image/x-icon" />
+
+    <!-- Social Media Metadata -->
+    <meta property="og:title" content="YoHello Chat" />
+    <meta
+      property="og:description"
+      content="Your website description goes here"
+    />
+    <meta property="og:image" content="/og-image.jpg" />
+    <meta name="twitter:card" content="/og-image.jpg" />
+
+    <!-- Add any other external libraries if needed -->
+  </head>
+
+  <body>
+    <div id="root"></div>
+    <script src="/dist/index.js"></script>
+  </body>
+</html>

--- a/examples/tool-calling/src/client/chat.tsx
+++ b/examples/tool-calling/src/client/chat.tsx
@@ -1,0 +1,64 @@
+import { useChat } from "ai/react";
+import { useState } from "react";
+
+type ChatProps = {
+  id: string;
+};
+
+export default function Chat(props: ChatProps) {
+  const { input, handleInputChange, setInput } = useChat();
+  const [messages, setMessages] = useState<{ role: string; content: string }[]>(
+    []
+  );
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    setMessages((prevMessages) => [
+      ...prevMessages,
+      { role: "user", content: input },
+    ]);
+    const currentInput = input;
+    setInput("");
+
+    const response = await fetch(`/api`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        messages: [{ role: "user", content: currentInput }],
+      }),
+    });
+
+    if (!response.ok) {
+      console.error("Failed to send message");
+      return;
+    }
+
+    const data = await response.text();
+
+    if (data) {
+      setMessages((prevMessages) => [
+        ...prevMessages,
+        { role: "assistant", content: data },
+      ]);
+    }
+  };
+
+  return (
+    <>
+      {messages.map((message) => (
+        <div key={message.id}>
+          {message.role === "user" ? "User: " : "AI: "}
+          {message.content}
+        </div>
+      ))}
+
+      <form onSubmit={handleSubmit}>
+        <input name="prompt" value={input} onChange={handleInputChange} />
+        <button type="submit">Submit</button>
+      </form>
+    </>
+  );
+}

--- a/examples/tool-calling/src/client/index.tsx
+++ b/examples/tool-calling/src/client/index.tsx
@@ -1,0 +1,10 @@
+import { createRoot } from "react-dom/client";
+import Chat from "./chat";
+
+function App() {
+  return <Chat id="example-room" />;
+}
+
+const root = createRoot(document.getElementById("root")!);
+
+root.render(<App />);

--- a/examples/tool-calling/src/client/tsconfig.json
+++ b/examples/tool-calling/src/client/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["DOM", "ESNext"]
+  }
+}

--- a/examples/tool-calling/src/server/index.ts
+++ b/examples/tool-calling/src/server/index.ts
@@ -1,0 +1,43 @@
+import { generateText, tool, type Message } from "ai";
+import { createWorkersAI } from "workers-ai-provider/src";
+import z from "zod";
+
+export interface Env {
+  AI: Ai;
+}
+
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+
+    if (request.method === "POST") {
+      const { messages } = await request.json<{
+        messages: Message[];
+      }>();
+      const workersai = createWorkersAI({ binding: env.AI });
+      const model = workersai("@cf/meta/llama-3.3-70b-instruct-fp8-fast");
+
+      const weather = tool({
+        description: "Get the weather in a location",
+        parameters: z.object({
+          location: z.string().describe("The location to get the weather for"),
+        }),
+        execute: async ({ location }) =>
+          location === "London" ? "Raining" : "Sunny",
+      });
+
+      const result = await generateText({
+        model,
+        messages,
+        tools: {
+          weather,
+        },
+        maxSteps: 5,
+      });
+
+      return new Response(result.text);
+    }
+
+    return new Response("Not Found!!", { status: 404 });
+  },
+} satisfies ExportedHandler<Env>;

--- a/examples/tool-calling/src/server/tsconfig.json
+++ b/examples/tool-calling/src/server/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["@cloudflare/workers-types"]
+  }
+}

--- a/examples/tool-calling/wrangler.toml
+++ b/examples/tool-calling/wrangler.toml
@@ -1,0 +1,11 @@
+name = "workers-ai-tool-calling"
+main = "src/server/index.ts"
+compatibility_date = "2024-07-31"
+
+assets = { directory = 'public' }
+
+[ai]
+binding = "AI"
+
+[build]
+command = "esbuild src/client/index.tsx --outdir=public/dist --bundle --sourcemap --format=esm --splitting"

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,13 +26,114 @@
       "dependencies": {
         "ai": "^4.0.14",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "zod": "^3.24.2"
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "^4.20241205.0",
+        "@cloudflare/workers-types": "^4.20250214.0",
         "@types/react": "^19.0.1",
         "@types/react-dom": "^19.0.2",
         "wrangler": "3.95.0"
+      }
+    },
+    "examples/ai-chat/node_modules/@cloudflare/workers-types": {
+      "version": "4.20250214.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20250214.0.tgz",
+      "integrity": "sha512-+M8oOFVbyXT5GeJrYLWMUGyPf5wGB4+k59PPqdedtOig7NjZ5r4S79wMdaZ/EV5IV8JPtZBSNjTKpDnNmfxjaQ==",
+      "dev": true
+    },
+    "examples/ai-chat/node_modules/zod": {
+      "version": "3.24.2",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
+      "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "examples/tool-calling": {
+      "name": "@cloudflare/example-tool-calling",
+      "dependencies": {
+        "@ai-sdk/openai": "^1.1.9",
+        "ai": "^4.0.14",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "zod": "^3.24.2"
+      },
+      "devDependencies": {
+        "@cloudflare/workers-types": "^4.20250214.0",
+        "@types/react": "^19.0.1",
+        "@types/react-dom": "^19.0.2",
+        "wrangler": "3.95.0"
+      }
+    },
+    "examples/tool-calling/node_modules/@cloudflare/workers-types": {
+      "version": "4.20250214.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20250214.0.tgz",
+      "integrity": "sha512-+M8oOFVbyXT5GeJrYLWMUGyPf5wGB4+k59PPqdedtOig7NjZ5r4S79wMdaZ/EV5IV8JPtZBSNjTKpDnNmfxjaQ==",
+      "dev": true
+    },
+    "examples/tool-calling/node_modules/zod": {
+      "version": "3.24.2",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
+      "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@ai-sdk/openai": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-1.1.13.tgz",
+      "integrity": "sha512-IdChK1pJTW3NQis02PG/hHTG0gZSyQIMOLPt7f7ES56C0xH2yaKOU1Tp2aib7pZzWGwDlzTOW2h5TtAB8+V6CQ==",
+      "dependencies": {
+        "@ai-sdk/provider": "1.0.8",
+        "@ai-sdk/provider-utils": "2.1.9"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.0.0"
+      }
+    },
+    "node_modules/@ai-sdk/openai/node_modules/@ai-sdk/provider": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-1.0.8.tgz",
+      "integrity": "sha512-f9jSYwKMdXvm44Dmab1vUBnfCDSFfI5rOtvV1W9oKB7WYHR5dGvCC6x68Mk3NUfrdmNoMVHGoh6JT9HCVMlMow==",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/openai/node_modules/@ai-sdk/provider-utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-2.1.9.tgz",
+      "integrity": "sha512-NerKjTuuUUs6glJGaentaXEBH52jRM0pR+cRCzc7aWke/K5jYBD6Frv1JYBpcxS7gnnCqSQZR9woiyS+6jrdjw==",
+      "dependencies": {
+        "@ai-sdk/provider": "1.0.8",
+        "eventsource-parser": "^3.0.0",
+        "nanoid": "^3.3.8",
+        "secure-json-parse": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ai-sdk/openai/node_modules/eventsource-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.0.tgz",
+      "integrity": "sha512-T1C0XCUimhxVQzW4zFipdx0SficT651NnkR0ZSH3yQwh+mFMdLfgjABVi4YtMTtaL4s168593DaoaRLMqryavA==",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@ai-sdk/provider": {
@@ -458,6 +559,10 @@
       "resolved": "examples/ai-chat",
       "link": true
     },
+    "node_modules/@cloudflare/example-tool-calling": {
+      "resolved": "examples/tool-calling",
+      "link": true
+    },
     "node_modules/@cloudflare/kv-asset-handler": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.3.4.tgz",
@@ -575,7 +680,9 @@
       "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20241205.0.tgz",
       "integrity": "sha512-pj1VKRHT/ScQbHOIMFODZaNAlJHQHdBSZXNIdr9ebJzwBff9Qz8VdqhbhggV7f+aUEh8WSbrsPIo4a+WtgjUvw==",
       "dev": true,
-      "license": "MIT OR Apache-2.0"
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -4488,8 +4595,14 @@
         "zod": "^3.24.1"
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "^4.20241205.0"
+        "@cloudflare/workers-types": "^4.20250214.0"
       }
+    },
+    "packages/ai-provider/node_modules/@cloudflare/workers-types": {
+      "version": "4.20250214.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20250214.0.tgz",
+      "integrity": "sha512-+M8oOFVbyXT5GeJrYLWMUGyPf5wGB4+k59PPqdedtOig7NjZ5r4S79wMdaZ/EV5IV8JPtZBSNjTKpDnNmfxjaQ==",
+      "dev": true
     }
   }
 }

--- a/packages/ai-provider/package.json
+++ b/packages/ai-provider/package.json
@@ -41,6 +41,6 @@
     "serverless"
   ],
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20241205.0"
+    "@cloudflare/workers-types": "^4.20250214.0"
   }
 }

--- a/packages/ai-provider/src/index.ts
+++ b/packages/ai-provider/src/index.ts
@@ -1,9 +1,10 @@
 import { WorkersAIChatLanguageModel } from "./workersai-chat-language-model";
 import type { WorkersAIChatSettings } from "./workersai-chat-settings";
+import type { TextGenerationModels } from "./workersai-models";
 
 export interface WorkersAI {
   (
-    modelId: BaseAiTextGenerationModels,
+    modelId: TextGenerationModels,
     settings?: WorkersAIChatSettings
   ): WorkersAIChatLanguageModel;
 
@@ -11,21 +12,21 @@ export interface WorkersAI {
    * Creates a model for text generation.
    **/
   chat(
-    modelId: BaseAiTextGenerationModels,
+    modelId: TextGenerationModels,
     settings?: WorkersAIChatSettings
   ): WorkersAIChatLanguageModel;
 }
 
 export interface WorkersAISettings {
   /**
-   * Provide an `env.AI` binding to use for the AI inference. 
-   * You can set up an AI bindings in your Workers project 
-   * by adding the following this to `wrangler.toml`: 
-  
+   * Provide an `env.AI` binding to use for the AI inference.
+   * You can set up an AI bindings in your Workers project
+   * by adding the following this to `wrangler.toml`:
+
   ```toml
 [ai]
 binding = "AI"
-  ``` 
+  ```
    **/
   binding: Ai;
 }
@@ -35,7 +36,7 @@ binding = "AI"
  **/
 export function createWorkersAI(options: WorkersAISettings): WorkersAI {
   const createChatModel = (
-    modelId: BaseAiTextGenerationModels,
+    modelId: TextGenerationModels,
     settings: WorkersAIChatSettings = {}
   ) =>
     new WorkersAIChatLanguageModel(modelId, settings, {
@@ -44,7 +45,7 @@ export function createWorkersAI(options: WorkersAISettings): WorkersAI {
     });
 
   const provider = function (
-    modelId: BaseAiTextGenerationModels,
+    modelId: TextGenerationModels,
     settings?: WorkersAIChatSettings
   ) {
     if (new.target) {

--- a/packages/ai-provider/src/workersai-chat-language-model.ts
+++ b/packages/ai-provider/src/workersai-chat-language-model.ts
@@ -195,7 +195,6 @@ export class WorkersAIChatLanguageModel implements LanguageModelV1 {
               if (!singleChunk.data) {
                 continue;
               }
-
               if (singleChunk.data === "[DONE]") {
                 controller.enqueue({
                   type: "finish",

--- a/packages/ai-provider/src/workersai-chat-language-model.ts
+++ b/packages/ai-provider/src/workersai-chat-language-model.ts
@@ -1,21 +1,13 @@
 import {
   type LanguageModelV1,
   type LanguageModelV1CallWarning,
-  type LanguageModelV1FinishReason,
   type LanguageModelV1StreamPart,
   UnsupportedFunctionalityError,
 } from "@ai-sdk/provider";
-import type {
-  ParseResult,
-  createEventSourceResponseHandler,
-  createJsonResponseHandler,
-  postJsonToApi,
-} from "@ai-sdk/provider-utils";
 import { z } from "zod";
 import { convertToWorkersAIChatMessages } from "./convert-to-workersai-chat-messages";
-import { mapWorkersAIFinishReason } from "./map-workersai-finish-reason";
 import type { WorkersAIChatSettings } from "./workersai-chat-settings";
-import { workersAIFailedResponseHandler } from "./workersai-error";
+import type { TextGenerationModels } from "./workersai-models";
 
 import { events } from "fetch-event-stream";
 
@@ -28,13 +20,13 @@ export class WorkersAIChatLanguageModel implements LanguageModelV1 {
   readonly specificationVersion = "v1";
   readonly defaultObjectGenerationMode = "json";
 
-  readonly modelId: BaseAiTextGenerationModels;
+  readonly modelId: TextGenerationModels;
   readonly settings: WorkersAIChatSettings;
 
   private readonly config: WorkersAIChatConfig;
 
   constructor(
-    modelId: BaseAiTextGenerationModels,
+    modelId: TextGenerationModels,
     settings: WorkersAIChatSettings,
     config: WorkersAIChatConfig
   ) {
@@ -105,6 +97,7 @@ export class WorkersAIChatLanguageModel implements LanguageModelV1 {
           args: {
             ...baseArgs,
             response_format: { type: "json_object" },
+            tools: undefined,
           },
           warnings,
         };
@@ -141,32 +134,35 @@ export class WorkersAIChatLanguageModel implements LanguageModelV1 {
   ): Promise<Awaited<ReturnType<LanguageModelV1["doGenerate"]>>> {
     const { args, warnings } = this.getArgs(options);
 
-    const response = await this.config.binding.run(args.model, {
-      messages: args.messages,
-    }, 
-    {
-      gateway: this.settings.gateway
-    });
+    const output = await this.config.binding.run(
+      args.model,
+      {
+        messages: args.messages,
+        tools: args.tools,
+      },
+      {
+        gateway: this.settings.gateway,
+      }
+    );
 
-    if (response instanceof ReadableStream) {
+    if (output instanceof ReadableStream) {
       throw new Error("This shouldn't happen");
     }
 
     return {
-      text: response.response,
-      // TODO: tool calls
-      // toolCalls: response.tool_calls?.map((toolCall) => ({
-      //   toolCallType: "function",
-      //   toolCallId: toolCall.name, // TODO: what can the id be?
-      //   toolName: toolCall.name,
-      //   args: JSON.stringify(toolCall.arguments || {}),
-      // })),
+      text: output.response,
+      toolCalls: output.tool_calls?.map((toolCall) => ({
+        toolCallType: "function",
+        toolCallId: toolCall.name,
+        toolName: toolCall.name,
+        args: JSON.stringify(toolCall.arguments || {}),
+      })),
       finishReason: "stop", // TODO: mapWorkersAIFinishReason(response.finish_reason),
       rawCall: { rawPrompt: args.messages, rawSettings: args },
       usage: {
-        // TODO: mapWorkersAIUsage(response.usage),
-        promptTokens: 0,
-        completionTokens: 0,
+	    // TODO: mapWorkersAIUsage(response.usage),
+  		promptTokens: 0,
+	    completionTokens: 0,
       },
       warnings,
     };
@@ -182,6 +178,7 @@ export class WorkersAIChatLanguageModel implements LanguageModelV1 {
     const response = await this.config.binding.run(args.model, {
       messages: args.messages,
       stream: true,
+      tools: args.tools,
     });
 
     if (!(response instanceof ReadableStream)) {
@@ -190,17 +187,15 @@ export class WorkersAIChatLanguageModel implements LanguageModelV1 {
 
     return {
       stream: response.pipeThrough(
-        new TransformStream<
-          ParseResult<z.infer<typeof workersAIChatChunkSchema>>,
-          LanguageModelV1StreamPart
-        >({
+        new TransformStream<Uint8Array, LanguageModelV1StreamPart>({
           async transform(chunk, controller) {
-            const chunkToText = decoder.decode(chunk as unknown as Uint8Array);
+            const chunkToText = decoder.decode(chunk);
             const chunks = events(new Response(chunkToText));
             for await (const singleChunk of chunks) {
               if (!singleChunk.data) {
                 continue;
               }
+
               if (singleChunk.data === "[DONE]") {
                 controller.enqueue({
                   type: "finish",

--- a/packages/ai-provider/src/workersai-error.ts
+++ b/packages/ai-provider/src/workersai-error.ts
@@ -1,8 +1,6 @@
 import {
   createJsonErrorResponseHandler,
-  type ResponseHandler,
 } from "@ai-sdk/provider-utils";
-import type { APICallError } from "ai";
 import { z } from "zod";
 
 const workersAIErrorDataSchema = z.object({
@@ -13,9 +11,7 @@ const workersAIErrorDataSchema = z.object({
   code: z.string().nullable(),
 });
 
-export type WorkersAIErrorData = z.infer<typeof workersAIErrorDataSchema>;
-
-export const workersAIFailedResponseHandler: ResponseHandler<APICallError> =
+export const workersAIFailedResponseHandler =
   createJsonErrorResponseHandler({
     errorSchema: workersAIErrorDataSchema,
     errorToMessage: (data) => data.message,

--- a/packages/ai-provider/src/workersai-models.ts
+++ b/packages/ai-provider/src/workersai-models.ts
@@ -1,0 +1,5 @@
+export type TextGenerationModels = {
+  // For each key K in AiModels, if the corresponding value is assignable to BaseAiTextGeneration,
+  // then keep the key; otherwise, assign it to never.
+  [K in keyof AiModels]: AiModels[K] extends BaseAiTextGeneration ? K : never;
+}[keyof AiModels];

--- a/packages/ai-provider/src/workersai-models.ts
+++ b/packages/ai-provider/src/workersai-models.ts
@@ -1,5 +1,6 @@
+/**
+ * The names of the BaseAiTextGeneration models.
+ */
 export type TextGenerationModels = {
-  // For each key K in AiModels, if the corresponding value is assignable to BaseAiTextGeneration,
-  // then keep the key; otherwise, assign it to never.
   [K in keyof AiModels]: AiModels[K] extends BaseAiTextGeneration ? K : never;
 }[keyof AiModels];

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -102,7 +102,7 @@
     // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
 
     /* Completeness */
-    // "skipDefaultLibCheck": true, /* Skip type checking .d.ts files that are included with TypeScript. */
+    // "skipDefaultLibCheck": true, 					 /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true /* Skip type checking all .d.ts files. */
   }
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -102,7 +102,7 @@
     // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
 
     /* Completeness */
-    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
+    // "skipDefaultLibCheck": true, /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true /* Skip type checking all .d.ts files. */
   }
 }


### PR DESCRIPTION
This adds the ability to call tools to the `generateText` helper. It also creates a new example to show off this new capability.

```
npm install
cd examples/tool-calling
npm start
```

Then ask it what is the weather like in London.

This PR also does a few other miscellaneous house-keeping things:
- updates `@cloudflare/workers-types`
- fixes some typing that had got out of date