### PR TITLE
Exclude BaseAiTextToImage model

### DIFF
--- a/.changeset/slimy-birds-add.md
+++ b/.changeset/slimy-birds-add.md
@@ -1,0 +1,5 @@
+---
+"workers-ai-provider": patch
+---
+
+Exclude BaseAiTextToImage model

--- a/packages/ai-provider/src/workersai-models.ts
+++ b/packages/ai-provider/src/workersai-models.ts
@@ -1,6 +1,9 @@
 /**
  * The names of the BaseAiTextGeneration models.
  */
-export type TextGenerationModels = {
-  [K in keyof AiModels]: AiModels[K] extends BaseAiTextGeneration ? K : never;
-}[keyof AiModels];
+export type TextGenerationModels = Exclude<
+  value2key<AiModels, BaseAiTextGeneration>,
+  value2key<AiModels, BaseAiTextToImage>
+>;
+
+type value2key<T, V> = { [K in keyof T]: T[K] extends V ? K : never }[keyof T];


### PR DESCRIPTION
Excluding BaseAiTextToImage models such as `@cf/stabilityai/stable-diffusion-xl-base-1.0`