### PR TITLE
fix: ensure tool calling works when streaming

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{js,jsx,ts,tsx,json,css,html}]
+indent_style = space
+indent_size = 2
+
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2

--- a/examples/ai-chat/src/server/index.ts
+++ b/examples/ai-chat/src/server/index.ts
@@ -26,28 +26,23 @@ export default {
         execute: async ({ location }) =>
           location === "London" ? "Raining" : "Sunny",
       });
-      try {
-        const result = streamText({
-          model: workersai("@cf/meta/llama-3.3-70b-instruct-fp8-fast"),
-          messages: convertToCoreMessages(messages),
-          tools: {
-            weather
-          },
-          maxSteps: 5,
-        });
-        return result.toDataStreamResponse({
-          headers: {
-            // add these headers to ensure that the
-            // response is chunked and streamed
-            "Content-Type": "text/x-unknown",
-            "content-encoding": "identity",
-            "transfer-encoding": "chunked",
-          },
-        });
-      } catch (e) {
-        console.log(JSON.stringify(e));
-      }
-
+      const result = streamText({
+        model: workersai("@cf/meta/llama-3.3-70b-instruct-fp8-fast"),
+        messages: convertToCoreMessages(messages),
+        tools: {
+          weather
+        },
+        maxSteps: 5,
+      });
+      return result.toDataStreamResponse({
+        headers: {
+          // add these headers to ensure that the
+          // response is chunked and streamed
+          "Content-Type": "text/x-unknown",
+          "content-encoding": "identity",
+          "transfer-encoding": "chunked",
+        },
+      });
     }
 
     return new Response("Not Found!!", { status: 404 });

--- a/packages/ai-provider/src/workersai-chat-language-model.ts
+++ b/packages/ai-provider/src/workersai-chat-language-model.ts
@@ -11,6 +11,7 @@ import type { TextGenerationModels } from "./workersai-models";
 
 import { events } from "fetch-event-stream";
 import { mapWorkersAIUsage } from "./map-workersai-usage";
+import type {WorkersAIChatPrompt} from "./workersai-chat-prompt";
 
 type WorkersAIChatConfig = {
   provider: string;
@@ -180,6 +181,47 @@ export class WorkersAIChatLanguageModel implements LanguageModelV1 {
   ): Promise<Awaited<ReturnType<LanguageModelV1["doStream"]>>> {
     const { args, warnings } = this.getArgs(options);
 
+    // [1] When the latest message is not a tool response, we use the regular generate function
+    // and simulate it as a streamed response in order to satisfy the AI SDK's interface for
+    // doStream...
+    if (lastMessageWasUser(args.messages)) {
+      const response = await this.doGenerate(options);
+
+      if ((response instanceof ReadableStream)) {
+        throw new Error("This shouldn't happen");
+      }
+
+      return {
+        stream: new ReadableStream<LanguageModelV1StreamPart>({
+          async start(controller) {
+            if (response.text) {
+              controller.enqueue({
+                type: "text-delta",
+                textDelta: response.text,
+              })
+            }
+            if (response.toolCalls) {
+              for (const toolCall of response.toolCalls) {
+                controller.enqueue({
+                  type: "tool-call",
+                  ...toolCall,
+                })
+              }
+            }
+            controller.enqueue({
+              type: "finish",
+              finishReason: "stop",
+              usage: response.usage,
+            });
+            controller.close();
+          },
+        }),
+        rawCall: { rawPrompt: args.messages, rawSettings: args },
+        warnings,
+      };
+    }
+
+    // [2] ...otherwise, we just proceed as normal and stream the response directly from the remote model.
     const response = await this.config.binding.run(
       args.model,
       {
@@ -189,6 +231,8 @@ export class WorkersAIChatLanguageModel implements LanguageModelV1 {
         temperature: args.temperature,
         tools: args.tools,
         top_p: args.top_p,
+        // @ts-expect-error response_format not yet added to types
+        response_format: args.response_format,
       },
       { gateway: this.config.gateway ?? this.settings.gateway }
     );
@@ -296,4 +340,8 @@ function prepareToolsAndToolChoice(
       throw new Error(`Unsupported tool choice type: ${exhaustiveCheck}`);
     }
   }
+}
+
+function lastMessageWasUser(messages: WorkersAIChatPrompt) {
+  return messages.length > 0 && messages[messages.length - 1].role === "user";
 }

--- a/packages/ai-provider/src/workersai-chat-language-model.ts
+++ b/packages/ai-provider/src/workersai-chat-language-model.ts
@@ -11,7 +11,7 @@ import type { TextGenerationModels } from "./workersai-models";
 
 import { events } from "fetch-event-stream";
 import { mapWorkersAIUsage } from "./map-workersai-usage";
-import type {WorkersAIChatPrompt} from "./workersai-chat-prompt";
+import type { WorkersAIChatPrompt } from "./workersai-chat-prompt";
 
 type WorkersAIChatConfig = {
   provider: string;
@@ -184,7 +184,7 @@ export class WorkersAIChatLanguageModel implements LanguageModelV1 {
     // [1] When the latest message is not a tool response, we use the regular generate function
     // and simulate it as a streamed response in order to satisfy the AI SDK's interface for
     // doStream...
-    if (lastMessageWasUser(args.messages)) {
+    if (args.tools?.length && lastMessageWasUser(args.messages)) {
       const response = await this.doGenerate(options);
 
       if ((response instanceof ReadableStream)) {


### PR DESCRIPTION
This ensures that when a tool call is made, we simulate the stream initially. This allows us to get the response from the initial call, and then populate the stream with any tool calls.