### PR TITLE
feat: add ability to use credentials instead of binding

### DIFF
--- a/.changeset/quick-walls-check.md
+++ b/.changeset/quick-walls-check.md
@@ -1,0 +1,5 @@
+---
+"workers-ai-provider": minor
+---
+
+feat: adds the ability to use the provider outside of the workerd environment by providing Cloudflare accountId/apiKey credentials.

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
       "dependencies": {
         "@changesets/changelog-github": "^0.5.0",
         "@changesets/cli": "^2.27.10",
+        "@cloudflare/workers-types": "^4.20250313.0",
         "@types/node": "^22.10.2",
         "esbuild": "^0.24.0",
         "tsup": "^8.3.5",
@@ -1936,13 +1937,10 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "4.20241205.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20241205.0.tgz",
-      "integrity": "sha512-pj1VKRHT/ScQbHOIMFODZaNAlJHQHdBSZXNIdr9ebJzwBff9Qz8VdqhbhggV7f+aUEh8WSbrsPIo4a+WtgjUvw==",
-      "dev": true,
-      "license": "MIT OR Apache-2.0",
-      "optional": true,
-      "peer": true
+      "version": "4.20250313.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20250313.0.tgz",
+      "integrity": "sha512-iqyzZwogC+3yL8h58vMhjYQUHUZA8XazE3Q+ofR59wDOnsPe/u9W6+aCl408N0iNBhMPvpJQQ3/lkz0iJN2fhA==",
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@changesets/changelog-github": "^0.5.0",
     "@changesets/cli": "^2.27.10",
+    "@cloudflare/workers-types": "^4.20250313.0",
     "@types/node": "^22.10.2",
     "esbuild": "^0.24.0",
     "tsup": "^8.3.5",

--- a/packages/ai-provider/README.md
+++ b/packages/ai-provider/README.md
@@ -58,6 +58,25 @@ export default {
 };
 ```
 
+You can also use your Cloudflare credentials to create the provider, for example if you want to use Cloudflare AI outside of the Worker environment. For example, here is how you can use Cloudflare AI in a Node script:
+
+```js
+const workersai = createWorkersAI({
+  accountId: process.env.CLOUDFLARE_ACCOUNT_ID,
+  apiKey: process.env.CLOUDFLARE_API_KEY
+});
+
+const text = await streamText({
+  model: workersai("@cf/meta/llama-2-7b-chat-int8"),
+  messages: [
+    {
+      role: "user",
+      content: "Write an essay about hello world",
+    },
+  ],
+});
+```
+
 For more info, refer to the documentation of the [Vercel AI SDK](https://sdk.vercel.ai/).
 
 ### Credits

--- a/packages/ai-provider/src/index.ts
+++ b/packages/ai-provider/src/index.ts
@@ -1,6 +1,37 @@
 import { WorkersAIChatLanguageModel } from "./workersai-chat-language-model";
 import type { WorkersAIChatSettings } from "./workersai-chat-settings";
 import type { TextGenerationModels } from "./workersai-models";
+import { createRun } from "./utils";
+
+export type WorkersAISettings =
+  ({
+  /**
+   * Provide a Cloudflare AI binding.
+   */
+  binding: Ai;
+
+  /**
+   * Credentials must be absent when a binding is given.
+   */
+  accountId?: never;
+  apiKey?: never;
+}
+  | {
+  /**
+   * Provide Cloudflare API credentials directly. Must be used if a binding is not specified.
+   */
+  accountId: string;
+  apiKey: string;
+  /**
+   * Both binding must be absent if credentials are used directly.
+   */
+  binding?: never;
+}) & {
+  /**
+   * Optionally specify a gateway.
+   */
+  gateway?: GatewayOptions;
+};
 
 export interface WorkersAI {
   (
@@ -17,36 +48,40 @@ export interface WorkersAI {
   ): WorkersAIChatLanguageModel;
 }
 
-export interface WorkersAISettings {
-  /**
-   * Provide an `env.AI` binding to use for the AI inference.
-   * You can set up an AI bindings in your Workers project
-   * by adding the following this to `wrangler.toml`:
-
-  ```toml
-[ai]
-binding = "AI"
-  ```
-   **/
-  binding: Ai;
-  /**
-   * Optionally set Cloudflare AI Gateway options.
-   */
-  gateway?: GatewayOptions;
-}
-
 /**
  * Create a Workers AI provider instance.
- **/
+ */
 export function createWorkersAI(options: WorkersAISettings): WorkersAI {
+  // Use a binding if one is directly provided. Otherwise use credentials to create
+  // a `run` method that calls the Cloudflare REST API.
+  let binding: Ai | undefined;
+
+  if (options.binding) {
+    binding = options.binding;
+  } else {
+    const { accountId, apiKey } = options;
+    binding = {
+      run: createRun(accountId, apiKey),
+    } as Ai;
+  }
+
+  if (!binding) {
+    throw new Error(
+      "Either a binding or credentials must be provided."
+    );
+  }
+
+  /**
+   * Helper function to create a chat model instance.
+   */
   const createChatModel = (
     modelId: TextGenerationModels,
     settings: WorkersAIChatSettings = {}
   ) =>
     new WorkersAIChatLanguageModel(modelId, settings, {
       provider: "workersai.chat",
-      binding: options.binding,
-      gateway: options.gateway,
+      binding,
+      gateway: options.gateway
     });
 
   const provider = function (
@@ -58,7 +93,6 @@ export function createWorkersAI(options: WorkersAISettings): WorkersAI {
         "The WorkersAI model function cannot be called with the new keyword."
       );
     }
-
     return createChatModel(modelId, settings);
   };
 
@@ -66,3 +100,4 @@ export function createWorkersAI(options: WorkersAISettings): WorkersAI {
 
   return provider;
 }
+

--- a/packages/ai-provider/src/utils.ts
+++ b/packages/ai-provider/src/utils.ts
@@ -1,0 +1,64 @@
+/**
+ * Creates a run method that mimics the Cloudflare Workers AI binding,
+ * but uses the Cloudflare REST API under the hood.
+ *
+ * @param accountId - Your Cloudflare account identifier.
+ * @param apiKey - Your Cloudflare API token/key with appropriate permissions.
+ * @returns An function matching `Ai['run']`.
+ */
+export function createRun(accountId: string, apiKey: string): AiRun {
+  return async <Name extends keyof AiModels>(model: Name, inputs: AiModels[Name]["inputs"], options?: AiOptions | undefined) => {
+    const url = `https://api.cloudflare.com/client/v4/accounts/${accountId}/ai/run/${model}`;
+    const body = JSON.stringify(inputs);
+
+    const headers = {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    };
+
+    const response = await fetch(url, {
+      method: "POST",
+      headers,
+      body,
+    }) as Response;
+
+    if (options?.returnRawResponse) {
+      return response;
+    }
+
+    if ((inputs as AiTextGenerationInput).stream === true) {
+      // If there's a stream, return the raw body so the caller can process it
+      if (response.body) {
+        return response.body;
+      }
+      throw new Error("No readable body available for streaming.");
+    }
+
+    // Otherwise, parse JSON and return the data.result
+    const data = await response.json<{ result: AiModels[Name]["postProcessedOutputs"] }>();
+    return data.result;
+  };
+}
+
+interface AiRun {
+  // (1) Return raw response if `options.returnRawResponse` is `true`.
+  <Name extends keyof AiModels>(
+    model: Name,
+    inputs: AiModels[Name]["inputs"],
+    options: AiOptions & { returnRawResponse: true }
+  ): Promise<Response>;
+
+  // (2) Return a stream if the input has `stream: true`.
+  <Name extends keyof AiModels>(
+    model: Name,
+    inputs: AiModels[Name]["inputs"] & { stream: true },
+    options?: AiOptions
+  ): Promise<ReadableStream<Uint8Array>>;
+
+  // (3) Return the post-processed outputs by default.
+  <Name extends keyof AiModels>(
+    model: Name,
+    inputs: AiModels[Name]["inputs"],
+    options?: AiOptions
+  ): Promise<AiModels[Name]["postProcessedOutputs"]>;
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["@cloudflare/workers-types/experimental"],
     /* Visit https://aka.ms/tsconfig to read more about this file */
 
     /* Projects */


### PR DESCRIPTION
Fixes: https://github.com/cloudflare/workers-ai-provider/issues/11

Opens the possibility to use outside of the `workerd` environment.


```
const workersai = createWorkersAI({
  accountId: process.env.CLOUDFLARE_ACCOUNT_ID,
  apiKey: process.env.CLOUDFLARE_API_KEY
});

const { object } = await generateObject({
  model: workersai("@cf/meta/llama-3.1-8b-instruct"),
  schema: z.object({
    recipe: z.object({
      name: z.string(),
      ingredients: z.array(
        z.object({ name: z.string(), amount: z.string() })
      ),
      steps: z.array(z.string()),
    }),
  }),
  messages,
});

return new Response(JSON.stringify(object));
```